### PR TITLE
Improved rotation during export

### DIFF
--- a/src/main/java/com/glisco/isometricrenders/mixin/RenderTickCounterMixin.java
+++ b/src/main/java/com/glisco/isometricrenders/mixin/RenderTickCounterMixin.java
@@ -1,0 +1,23 @@
+package com.glisco.isometricrenders.mixin;
+
+import com.glisco.isometricrenders.property.GlobalProperties;
+import com.glisco.isometricrenders.screen.RenderScreen;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.render.RenderTickCounter;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(RenderTickCounter.Dynamic.class)
+public class RenderTickCounterMixin {
+
+    @Shadow private long prevTimeMillis;
+
+    @ModifyVariable(method = "beginRenderTick(JZ)I", index = 1, argsOnly = true, at = @At("HEAD"))
+    public long test(long value) {
+        return MinecraftClient.getInstance().currentScreen instanceof RenderScreen rs && rs.remainingAnimationFrames > 0
+                ? this.prevTimeMillis + (1000L / GlobalProperties.exportFramerate) : value;
+    }
+
+}

--- a/src/main/java/com/glisco/isometricrenders/property/DefaultPropertyBundle.java
+++ b/src/main/java/com/glisco/isometricrenders/property/DefaultPropertyBundle.java
@@ -2,6 +2,7 @@ package com.glisco.isometricrenders.property;
 
 import com.glisco.isometricrenders.render.Renderable;
 import com.glisco.isometricrenders.screen.IsometricUI;
+import com.glisco.isometricrenders.screen.RenderScreen;
 import com.glisco.isometricrenders.util.ClientRenderCallback;
 import com.glisco.isometricrenders.util.Translate;
 import io.wispforest.owo.ui.component.ButtonComponent;
@@ -87,7 +88,9 @@ public class DefaultPropertyBundle implements PropertyBundle {
     protected void updateAndApplyRotationOffset(Matrix4fStack modelViewStack) {
         if (rotationSpeed.get() != 0) {
             if (!this.rotationOffsetUpdated) {
-                rotationOffset += MinecraftClient.getInstance().getRenderTickCounter().getLastFrameDuration() * rotationSpeed.get() * .1f;
+                float dur = MinecraftClient.getInstance().currentScreen instanceof RenderScreen rs && rs.remainingAnimationFrames > 0
+                        ? 20F / GlobalProperties.exportFramerate : MinecraftClient.getInstance().getRenderTickCounter().getLastFrameDuration();
+                rotationOffset += dur * rotationSpeed.get() * .1f;
                 this.rotationOffsetUpdated = true;
             }
             modelViewStack.rotate(RotationAxis.POSITIVE_Y.rotationDegrees(rotationOffset));

--- a/src/main/java/com/glisco/isometricrenders/property/DefaultPropertyBundle.java
+++ b/src/main/java/com/glisco/isometricrenders/property/DefaultPropertyBundle.java
@@ -75,8 +75,13 @@ public class DefaultPropertyBundle implements PropertyBundle {
         this.updateAndApplyRotationOffset(modelViewStack);
     }
 
-    public float rotationOffset() {
+    public float getRotationOffset() {
         return this.rotationOffset;
+    }
+
+    public void setRotationOffset(int offset) {
+        this.rotationOffset = offset;
+        this.rotationOffsetUpdated = true;
     }
 
     protected void updateAndApplyRotationOffset(Matrix4fStack modelViewStack) {

--- a/src/main/java/com/glisco/isometricrenders/property/DefaultPropertyBundle.java
+++ b/src/main/java/com/glisco/isometricrenders/property/DefaultPropertyBundle.java
@@ -88,9 +88,7 @@ public class DefaultPropertyBundle implements PropertyBundle {
     protected void updateAndApplyRotationOffset(Matrix4fStack modelViewStack) {
         if (rotationSpeed.get() != 0) {
             if (!this.rotationOffsetUpdated) {
-                float dur = MinecraftClient.getInstance().currentScreen instanceof RenderScreen rs && rs.remainingAnimationFrames > 0
-                        ? 20F / GlobalProperties.exportFramerate : MinecraftClient.getInstance().getRenderTickCounter().getLastFrameDuration();
-                rotationOffset += dur * rotationSpeed.get() * .1f;
+                rotationOffset += MinecraftClient.getInstance().getRenderTickCounter().getLastFrameDuration() * rotationSpeed.get() * .1f;
                 this.rotationOffsetUpdated = true;
             }
             modelViewStack.rotate(RotationAxis.POSITIVE_Y.rotationDegrees(rotationOffset));

--- a/src/main/java/com/glisco/isometricrenders/render/DefaultRenderable.java
+++ b/src/main/java/com/glisco/isometricrenders/render/DefaultRenderable.java
@@ -51,7 +51,7 @@ public abstract class DefaultRenderable<P extends DefaultPropertyBundle> impleme
         Camera camera = MinecraftClient.getInstance().getEntityRenderDispatcher().camera;
         float previousYaw = camera.getYaw(), previousPitch = camera.getPitch();
 
-        ((CameraInvoker) camera).isometric$setRotation(this.properties().rotation.get() + 180 + this.properties().rotationOffset(), this.properties().slant.get());
+        ((CameraInvoker) camera).isometric$setRotation(this.properties().rotation.get() + 180 + this.properties().getRotationOffset(), this.properties().slant.get());
         action.accept(camera);
 
         ((CameraInvoker) camera).isometric$setRotation(previousYaw, previousPitch);

--- a/src/main/java/com/glisco/isometricrenders/screen/RenderScreen.java
+++ b/src/main/java/com/glisco/isometricrenders/screen/RenderScreen.java
@@ -97,7 +97,7 @@ public class RenderScreen extends BaseOwoScreen<FlowLayout> {
     private final FlowLayout rightColumn = Containers.verticalFlow(Sizing.fill(100), Sizing.content());
 
     private final List<Framebuffer> renderedFrames = new ArrayList<>();
-    private int remainingAnimationFrames;
+    public int remainingAnimationFrames;
 
     public RenderScreen(Renderable<?> renderable) {
         this.renderable = renderable;

--- a/src/main/java/com/glisco/isometricrenders/screen/RenderScreen.java
+++ b/src/main/java/com/glisco/isometricrenders/screen/RenderScreen.java
@@ -251,7 +251,9 @@ public class RenderScreen extends BaseOwoScreen<FlowLayout> {
                 framerateField.setTextPredicate(s -> s.matches("\\d*"));
                 framerateField.setChangedListener(s -> {
                     if (s.isBlank()) return;
-                    exportFramerate = Integer.parseInt(s);
+                    int rate = Integer.parseInt(s);
+                    if (rate != 0)
+                        exportFramerate = rate;
                 });
 
                 try (var builder = IsometricUI.row(rightColumn)) {

--- a/src/main/java/com/glisco/isometricrenders/screen/RenderScreen.java
+++ b/src/main/java/com/glisco/isometricrenders/screen/RenderScreen.java
@@ -257,6 +257,9 @@ public class RenderScreen extends BaseOwoScreen<FlowLayout> {
                 try (var builder = IsometricUI.row(rightColumn)) {
                     this.exportAnimationButton = Components.button(Translate.gui("export_animation"), button -> {
                         if (this.memoryGuard.canFit(this.estimateMemoryUsage(exportFrames)) || Screen.hasShiftDown()) {
+                            if (this.renderable.properties() instanceof DefaultPropertyBundle dpb) {
+                                dpb.setRotationOffset(0);
+                            }
                             this.remainingAnimationFrames = exportFrames;
 
                             this.client.getWindow().setFramerateLimit(Integer.parseInt(framerateField.getText()));

--- a/src/main/resources/isometric-renders.mixins.json
+++ b/src/main/resources/isometric-renders.mixins.json
@@ -5,11 +5,12 @@
   "compatibilityLevel": "JAVA_16",
   "plugin": "com.glisco.isometricrenders.mixin.IsometricMixinPlugin",
   "client": [
+    "DrawContextMixin",
     "HandledScreenMixin",
     "LivingEntityRendererMixin",
     "MinecraftClientMixin",
     "ParticleManagerMixin",
-    "DrawContextMixin",
+    "RenderTickCounterMixin",
     "SliderWidgetInvoker",
     "TextureManagerMixin",
     "WorldRendererMixin",


### PR DESCRIPTION
- When animated export started, it resets the rotation offset
- ~~When exporting, changes rotation by a consistent amount instead of using LastFrameDuration~~
- When exporting, tickcounter uses a consistent amount of time based on the export framerate
  - This solves weird jumps in exported rotations when there is some lag

The only worry I have, is that magic number 20. At least for me it matches what LastFrameDuration would be assuming no lag, but I'm not sure if there are times where this number would be wrong